### PR TITLE
Add Password Hash Block with Argon2id, Tests, Documentation, and Web Updates

### DIFF
--- a/apps/web/components/globals/Footer.tsx
+++ b/apps/web/components/globals/Footer.tsx
@@ -13,7 +13,7 @@ export function Footer() {
             rel="noopener noreferrer"
             className="text-foreground hover:text-primary transition-colors font-medium"
           >
-            codewithnuh
+            Noor ul hassan
           </Link>
         </p>
 

--- a/apps/web/components/globals/GithubStarBanner.tsx
+++ b/apps/web/components/globals/GithubStarBanner.tsx
@@ -1,39 +1,35 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
-import { Star, X } from "lucide-react";
+import { Star } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
-export function GithubStarBanner() {
-  const [visible, setVisible] = useState(true);
+interface GithubStarBannerProps {
+  /** Optional star count to show live social proof */
+  starCount?: string | number;
+}
 
-  if (!visible) return null;
-
+export function GithubStarBanner({ starCount }: GithubStarBannerProps) {
   return (
-    <Card className="relative overflow-hidden border-amber-300 bg-linear-to-r from-amber-50 via-yellow-50 to-amber-100 px-3 py-2">
-      <div className="container mx-auto">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => setVisible(false)}
-          className="absolute right-2 top-1 h-6 w-6 text-amber-700 hover:bg-amber-200 hover:text-amber-900"
-          aria-label="Dismiss banner"
-        >
-          <X className="h-3.5 w-3.5" />
-        </Button>
+    <Card className="group relative overflow-hidden rounded-xl border border-amber-500/20 bg-gradient-to-r from-amber-500/5 via-background to-background p-3 shadow-xs transition-all hover:border-amber-500/40 hover:shadow-md">
+      {/* Subtle accent line */}
+      <div aria-hidden="true" className="absolute inset-y-0 left-0 w-1 bg-amber-500 rounded-l-xl" />
 
-        <div className="flex items-center justify-between gap-3 pr-7">
-          <div className="flex min-w-0 items-center gap-2">
-            <div className="rounded-md bg-amber-600 p-1.5 text-white">
+      <div className="container mx-auto">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            {/* GitHub icon container */}
+            <div
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border/80 bg-muted/80 text-foreground transition-transform group-hover:scale-105"
+              aria-hidden="true"
+            >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"
                 className="h-4 w-4"
-                aria-hidden="true"
               >
                 <path
                   fillRule="evenodd"
@@ -43,19 +39,39 @@ export function GithubStarBanner() {
               </svg>
             </div>
 
-            <p className="truncate text-sm text-amber-900">
-              Like Blockend? Give it a ⭐ on GitHub.
-            </p>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-foreground">Enjoying Blockend?</p>
+
+              <p className="text-xs text-muted-foreground">
+                <span className="hidden sm:inline">
+                  Help us grow by giving standard support on GitHub.
+                </span>
+                <span className="sm:hidden">Give us a star on GitHub</span>
+              </p>
+            </div>
           </div>
 
-          <Button asChild size="sm" className="h-8 shrink-0 bg-amber-600  px-3 hover:bg-amber-700">
+          <Button
+            asChild
+            size="sm"
+            className="h-9 shrink-0 gap-2 rounded-lg bg-foreground px-3.5 text-xs font-medium text-background shadow-sm hover:bg-foreground/90 transition-all active:scale-95"
+          >
             <Link
               href="https://github.com/codewithnuh/blockend"
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="Star Blockend on GitHub (opens in a new tab)"
             >
-              <Star className="mr-1.5 h-3.5 w-3.5 fill-current" />
-              Star
+              <Star
+                className="h-3.5 w-3.5 fill-amber-400 text-amber-400 transition-transform duration-300 group-hover:rotate-12 group-hover:scale-110"
+                aria-hidden="true"
+              />
+              <span>Star on GitHub</span>
+              {starCount !== undefined && (
+                <span className="ml-1 rounded-md bg-background/20 px-1.5 py-0.5 text-[10px] font-semibold tracking-wider">
+                  {starCount}
+                </span>
+              )}
             </Link>
           </Button>
         </div>

--- a/apps/web/components/sections/BlocksCatalogSection.tsx
+++ b/apps/web/components/sections/BlocksCatalogSection.tsx
@@ -5,7 +5,8 @@ import { BLOCKS_CATALOG } from "@/lib/landing-constants";
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Copy, Check } from "lucide-react";
+import { Copy, Check, ArrowUpRight } from "lucide-react";
+import Link from "next/link";
 
 export function BlocksCatalogSection() {
   return (
@@ -15,16 +16,31 @@ export function BlocksCatalogSection() {
       className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-8"
     >
       {/* Header */}
-      <header className="mb-12">
-        <span className="font-mono text-[12px] text-muted-foreground dark:text-ash tracking-widest uppercase block transition-colors">
-          {BLOCKS_CATALOG.badge}
-        </span>
-        <h2
-          id="catalog-heading"
-          className="text-2xl sm:text-[32px] font-normal text-fg dark:text-paper tracking-tight mt-2 transition-colors"
+      <header className="mb-12 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <span className="font-mono text-[12px] text-muted-foreground dark:text-ash tracking-widest uppercase block transition-colors">
+            {BLOCKS_CATALOG.badge}
+          </span>
+
+          <h2
+            id="catalog-heading"
+            className="text-2xl sm:text-[32px] font-normal text-fg dark:text-paper tracking-tight mt-2 transition-colors"
+          >
+            {BLOCKS_CATALOG.headline}
+          </h2>
+        </div>
+
+        {/* Full Catalog CTA */}
+        <Button
+          asChild
+          variant="outline"
+          className="w-fit rounded-button border-border dark:border-graphite bg-transparent hover:bg-surface-2 dark:hover:bg-obsidian text-fg dark:text-paper font-mono text-[12px] font-normal"
         >
-          {BLOCKS_CATALOG.headline}
-        </h2>
+          <Link href="/docs/blocks-reference" aria-label="Browse the full Blockend catalog">
+            Browse Full Catalog
+            <ArrowUpRight className="ml-2 h-3.5 w-3.5" aria-hidden="true" />
+          </Link>
+        </Button>
       </header>
 
       {/* Grid of Catalog Cards */}
@@ -58,12 +74,12 @@ function BlockCard({ block }: { block: (typeof BLOCKS_CATALOG.blocks)[number] })
 
   return (
     <Card className="w-full p-5 rounded-card bg-surface border-border dark:bg-carbon dark:border-graphite flex flex-col justify-between space-y-4 shadow-sm transition-colors">
-      {/* Top Details */}
       <div className="space-y-2">
         <CardHeader className="p-0 flex flex-row items-center justify-between space-y-0">
           <CardTitle className="font-mono text-[12px] text-fg dark:text-paper font-normal transition-colors">
             {block.name}
           </CardTitle>
+
           <Badge
             variant="outline"
             className="px-1.5 py-0.5 rounded-badge bg-surface-2 border-border dark:bg-obsidian dark:border-graphite font-mono text-[10px] text-muted-foreground dark:text-fog font-normal transition-colors"
@@ -79,7 +95,6 @@ function BlockCard({ block }: { block: (typeof BLOCKS_CATALOG.blocks)[number] })
         </CardContent>
       </div>
 
-      {/* Bottom Command Strip & Copy Button */}
       <CardFooter className="p-0 py-3 border-t border-border dark:border-graphite flex justify-between items-center text-[11px] font-mono text-muted-foreground dark:text-ash transition-colors">
         <code className="text-[11px] font-mono text-muted-foreground dark:text-ash bg-transparent p-0 transition-colors">
           {block.command}
@@ -104,7 +119,6 @@ function BlockCard({ block }: { block: (typeof BLOCKS_CATALOG.blocks)[number] })
             )}
           </Button>
 
-          {/* Screen reader live region feedback */}
           <span className="sr-only" role="status" aria-live="polite">
             {copied ? `Command npx ${block.command} copied to clipboard` : ""}
           </span>

--- a/apps/web/components/sections/FrameworkSupportSection.tsx
+++ b/apps/web/components/sections/FrameworkSupportSection.tsx
@@ -35,13 +35,7 @@ function FrameworkIcon({ icon }: FrameworkIconProps) {
           className="w-4 h-4 text-red-600 dark:text-coral-red shrink-0 transition-colors"
         />
       );
-    case "n":
-      return (
-        <Layers
-          {...iconProps}
-          className="w-4 h-4 text-fg dark:text-paper shrink-0 transition-colors"
-        />
-      );
+
     default:
       return (
         <Terminal
@@ -61,7 +55,7 @@ export function FrameworkSupportSection() {
     >
       <Card className="p-8 md:p-14 rounded-card bg-surface border-border dark:bg-carbon dark:border-graphite text-center space-y-10 shadow-sm transition-colors border">
         {/* Section Header */}
-        <CardHeader className="p-0 flex flex-col items-center justify-center space-y-3">
+        <CardHeader className="p-0 flex  flex-col items-center justify-center space-y-3">
           <div>
             <Badge
               variant="outline"
@@ -89,10 +83,15 @@ export function FrameworkSupportSection() {
         <ul
           role="list"
           aria-label="Supported frameworks and runtimes"
-          className="grid grid-cols-2 sm:grid-cols-4 gap-3.5 max-w-2xl mx-auto font-mono text-[13px] list-none p-0 m-0"
+          className="grid grid-cols-2 sm:grid-cols-3 gap-3.5 max-w-2xl mx-auto font-mono text-[13px] list-none p-0 m-0"
         >
-          {FRAMEWORKS.items.map((fw) => (
-            <li key={fw.name} className="flex">
+          {FRAMEWORKS.items.map((fw, index) => (
+            <li
+              key={fw.name}
+              className={`flex items-center ${
+                index === 2 ? "col-span-2 sm:col-span-1 justify-center" : ""
+              }`}
+            >
               <div className="w-full py-3 px-4 rounded-btn bg-surface-2 border-border dark:bg-obsidian dark:border-graphite flex items-center justify-center gap-2.5 text-muted-foreground dark:text-mist hover:text-fg dark:hover:text-paper hover:border-border/80 dark:hover:border-smoke transition-colors">
                 <FrameworkIcon icon={fw.icon} />
                 <span className="whitespace-nowrap">{fw.name}</span>

--- a/apps/web/content/docs/02-blocks/10-password-hash.mdx
+++ b/apps/web/content/docs/02-blocks/10-password-hash.mdx
@@ -1,0 +1,534 @@
+---
+title: Password Hashing
+description: Argon2id password hashing with HMAC-SHA256 peppering, automatic salting, rehash detection, and fail-fast configuration validation.
+---
+
+import { Tabs, Tab } from "fumadocs-ui/components/tabs";
+import { Steps, Step } from "fumadocs-ui/components/steps";
+import { Callout } from "fumadocs-ui/components/callout";
+import { SourceCode } from "../../../components/source-code";
+
+The **Password Hashing** block provides production-grade password storage using Argon2id with HMAC-SHA256 peppering.
+
+Instead of wiring `@node-rs/argon2` by hand and inventing your own pepper, salt, and upgrade strategy, instantiate `PasswordHasher` once and get hashed credentials that exceed OWASP baselines, reject legacy algorithms, and detect weak or differing parameters for transparent rehashing on login.
+
+---
+
+## Features
+
+- Argon2id only — weaker variants (`argon2i`, `argon2d`) and foreign formats such as bcrypt are rejected during verification
+- HMAC-SHA256 peppering with a key that never appears in the stored hash
+- Unique 128-bit random salt generated for every hash
+- PHC-standard output (`$argon2id$v=19$m=...,t=...,p=...$salt$hash`)
+- `needsRehash()` detection for transparent parameter upgrades (memory, time, parallelism, output length, version)
+- Fail-fast configuration validation: strict base64 pepper checks and bounded numeric parameters
+- Byte-exact input limiting to prevent denial-of-service through oversized passwords
+- Explicit type checks — non-string passwords throw `TypeError`
+- Framework agnostic — plain async class usable in Express, Fastify, Hono, scripts, or queues
+
+<Callout type="info">
+  This block stores passwords. It does **not** authenticate requests, manage sessions, look up
+  users, or rate-limit login attempts. Those concerns belong to your application and the Rate
+  Limiter block.
+</Callout>
+
+---
+
+## File Structure
+
+```text
+password-hash
+├── types.ts
+├── errors.ts
+├── config.ts
+└── core.ts
+```
+
+- **types.ts** — `Argon2Params`, `PasswordHashConfig`, and override types.
+- **errors.ts** — `InvalidPepperError`, `InvalidConfigError`, `PasswordTooLongError`.
+- **config.ts** — Environment loading and validation (`loadConfig()`).
+- **core.ts** — The `PasswordHasher` service class.
+
+---
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+  <Tab value="CLI">
+```bash
+pnpm dlx blockend-cli add password-hash
+```
+
+<Steps>
+  <Step>
+    ### Detect Project
+
+    Blockend detects your project configuration and determines the correct output location.
+
+  </Step>
+  <Step>
+    ### Install Dependencies
+
+    `@node-rs/argon2` is installed automatically.
+
+  </Step>
+  <Step>
+    ### Generate Files
+
+    The password hashing block is generated inside your configured blocks directory.
+
+  </Step>
+</Steps>
+  </Tab>
+
+  <Tab value="Manual">
+Copy the files below into your project's blocks directory.
+
+### Peer Dependencies
+
+| Package           | Required |
+| ----------------- | -------- |
+| `@node-rs/argon2` | Yes      |
+
+### `blocks/password-hash/types.ts`
+
+Configuration interfaces for Argon2 parameters, full config, and overrides.
+
+<SourceCode file="password-hash/types.ts" />
+
+### `blocks/password-hash/errors.ts`
+
+Typed errors: invalid pepper, invalid configuration, oversized password.
+
+<SourceCode file="password-hash/errors.ts" />
+
+### `blocks/password-hash/config.ts`
+
+Loads and validates configuration from environment variables with optional overrides.
+
+<SourceCode file="password-hash/config.ts" />
+
+### `blocks/password-hash/core.ts`
+
+The `PasswordHasher` class implementing hashing, verification, and rehash detection.
+
+<SourceCode file="password-hash/core.ts" />
+  </Tab>
+</Tabs>
+
+---
+
+## Configuration
+
+Configuration resolves in order: **constructor override → environment variable → secure default**.
+
+### PasswordHashConfig
+
+| Option          | Type     | Default          | Description                                             |
+| --------------- | -------- | ---------------- | ------------------------------------------------------- |
+| `pepper`        | `string` | Required         | Base64-encoded secret; must decode to at least 32 bytes |
+| `memoryCost`    | `number` | `65536` (64 MiB) | Argon2 memory cost in KiB                               |
+| `timeCost`      | `number` | `3`              | Argon2 iterations                                       |
+| `parallelism`   | `number` | `1`              | Argon2 threads (keep `1` for web request handling)      |
+| `outputLen`     | `number` | `32`             | Hash output length in bytes                             |
+| `maxInputBytes` | `number` | `128`            | Maximum UTF-8 byte length accepted for a password       |
+
+### Environment Variables
+
+| Variable                   | Maps to         | Default  |
+| -------------------------- | --------------- | -------- |
+| `APP_PASSWORD_PEPPER`      | `pepper`        | Required |
+| `ARGON2_MEMORY_COST`       | `memoryCost`    | `65536`  |
+| `ARGON2_TIME_COST`         | `timeCost`      | `3`      |
+| `ARGON2_PARALLELISM`       | `parallelism`   | `1`      |
+| `ARGON2_OUTPUT_LEN`        | `outputLen`     | `32`     |
+| `PASSWORD_MAX_INPUT_BYTES` | `maxInputBytes` | `128`    |
+
+<Callout type="warn">
+  Validation is strict and fails at startup. The pepper must match the standard base64 alphabet and
+  decode to at least 32 bytes. Every numeric parameter must be an integer within its native binding
+  limits (`parallelism` maxes out at 255). Invalid values throw immediately — they are never
+  silently coerced into Argon2.
+</Callout>
+
+---
+
+## Security Recommendations
+
+This section covers what OWASP recommends and how to configure the block responsibly. Read it before deploying.
+
+### Follow the OWASP baseline — then exceed it deliberately
+
+The [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) recommends Argon2id with a minimum of **19 MiB memory, 2 iterations, 1 degree of parallelism**, and states that reduced memory must be compensated with more iterations. RFC 9106 offers a higher-memory variant at 46 MiB, 1 pass.
+
+Common starting points:
+
+| Scenario                      | `memoryCost` | `timeCost` | `parallelism` | Notes                                            |
+| ----------------------------- | ------------ | ---------- | ------------- | ------------------------------------------------ |
+| Block default                 | `65536`      | `3`        | `1`           | 64 MiB — above both OWASP and RFC 9106 baselines |
+| OWASP minimum                 | `19456`      | `2`        | `1`           | 19 MiB — acceptable floor, do not go below       |
+| High-throughput API           | `47104`      | `1`        | `1`           | 46 MiB, single pass                              |
+| Memory-constrained containers | `16384`      | `3`        | `1`           | Compensate lower memory with more iterations     |
+
+Two operational rules the cheat sheet implies and that you should enforce yourself:
+
+- **Measure on production hardware.** Keep hash and verify latency inside your interactive budget (typically under 500 ms). If login feels slow, users — and your support team — will notice.
+- **Budget total memory, not per-hash memory.** Every concurrent hash or verify holds `memoryCost` of RAM. Twenty simultaneous logins at 64 MiB is 1.25 GiB. Combine this block with the Rate Limiter on credential endpoints and queue bursts if needed.
+
+### Generate and store the pepper correctly
+
+The pepper is a symmetric secret mixed into every hash via HMAC-SHA256. Its entire value is that an attacker who steals your database _still cannot verify password guesses offline_ without also stealing the environment variable or secret.
+
+Generate it with real entropy:
+
+```bash
+openssl rand -base64 32
+# or
+node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
+```
+
+Non-negotiable rules:
+
+- At least 32 bytes of entropy — the block enforces this and will refuse to start otherwise.
+- Store it in a secret manager or your process environment. Never commit it, never hardcode it, never put it in the database next to the hashes.
+- Never log it. The block never includes the pepper in hashes, error messages, or stack traces — keep it that way in your own code.
+- Understand rotation: changing the pepper invalidates every stored hash, because verification recomputes the same HMAC. If you must rotate, support two peppers temporarily (verify against old, rehash with new) or schedule a password-reset campaign.
+
+### Rehash on login
+
+Parameter upgrades only take effect when you rewrite the stored hash. The standard pattern is to check `needsRehash()` after a successful verification and persist the stronger hash:
+
+```ts
+if (await hasher.verifyPassword(password, user.passwordHash)) {
+  if (hasher.needsRehash(user.passwordHash)) {
+    await users.updatePasswordHash(user.id, await hasher.hashPassword(password));
+  }
+}
+```
+
+Old hashes remain verifiable forever — Argon2 reads the parameters embedded in each PHC string — so upgrades are backward compatible and gradual. Hashes created with a different Argon2 version, different output length, unknown algorithms, or unreadable data always report `needsRehash: true`.
+
+### Know the limits you inherit
+
+Being explicit about what the block does and does not decide for you:
+
+- **Empty passwords hash successfully.** Minimum-length policy is an application decision (NIST SP 800-63B suggests allowing at least 64 characters and checking against breach corpora; many teams require 8–15). Enforce it at registration, not in the hashing layer.
+- **`maxInputBytes` counts bytes, not characters.** 128 bytes fits any 64-character ASCII password, but multi-byte scripts consume more: `€` is 3 bytes, emoji are 4. If your audience writes Japanese or uses emoji in passphrases, raise `PASSWORD_MAX_INPUT_BYTES`.
+- **Oversized input throws during hashing and during verification.** A 200-byte login attempt rejects with `PasswordTooLongError` instead of silently hashing truncated data.
+- **Non-string input throws `TypeError`.** The block does not coerce values.
+- **Verification returns `false` — it never throws — for anything that is not a well-formed Argon2id hash:** garbage strings, truncated PHC strings, bcrypt hashes, `argon2i`, `argon2d`. This is deliberate downgrade protection. Migrating off bcrypt means detecting the `$2b$` prefix yourself and rehashing after the user supplies the correct plaintext.
+- **No breach-list checking, no password strength scoring, no username-similarity rules.** Pair with a library like `zxcvbn` and the HaveIBeenPwned range API if your threat model calls for them.
+
+---
+
+## Architecture
+
+```text
+new PasswordHasher(overrides)
+│
+▼
+loadConfig() — override → env var → default, strict validation, fail fast
+│ ├── missing / non-base64 / short pepper → InvalidPepperError
+│ └── non-integer or out-of-range param → InvalidConfigError
+▼
+hashPassword(password)
+│
+▼
+applyPepper(password)
+├── typeof !== "string" → TypeError
+├── Buffer.byteLength > maxInputBytes → PasswordTooLongError
+└── HMAC-SHA256(key = decoded pepper bytes) → fixed 32-byte digest → base64
+│
+▼
+Argon2id(digest, random 16-byte salt, config params)
+│
+▼
+PHC string "$argon2id$v=19$m=65536,t=3,p=1$salt$hash" → store this
+```
+
+```text
+verifyPassword(password, storedHash)
+│
+├── not a string or not "$argon2id$..." → false (downgrade protection)
+├── applyPepper fails → TypeError / PasswordTooLongError propagates
+└── argon2 verify
+    ├── params read from the hash itself (backward compatible)
+    └── malformed hash → false, never throws
+```
+
+Each password is pre-hashed with HMAC-SHA256 keyed by the decoded pepper bytes. Because HMAC produces a fixed 32-byte digest, Argon2 always receives uniform-length input regardless of whether the user typed 4 characters or 100. The digest is handed to Argon2 as base64 so hashing and verification see identical bytes. The stored PHC string contains the salt and parameters but never the pepper.
+
+---
+
+## When to Use
+
+- You store user credentials and want OWASP-grade parameters enforced from startup, not by convention.
+- Your database may be exposed through backups, SQL injection, or misconfigured snapshots, and you want offline cracking to require a second stolen secret.
+- You plan to tune Argon2 costs over time and need old hashes to keep working while new ones get stronger parameters.
+
+## When Not to Use
+
+- You need full authentication (sessions, tokens, OAuth) — combine this block with your auth framework instead.
+- You are hashing API keys, reset tokens, or session identifiers — use SHA-256/HMAC directly; password hashing is intentionally slow.
+- You run on hardware where 19 MiB per concurrent attempt already exhausts memory — reduce `memoryCost` explicitly and compensate with iterations rather than failing at runtime.
+
+---
+
+## Usage
+
+### Setup
+
+Generate a pepper, put it in your environment, and instantiate one hasher for the whole application:
+
+```bash
+# .env — generate with: openssl rand -base64 32
+APP_PASSWORD_PEPPER="Zm9vYmFyYmF6cXV1eGZvb2JhcmJhenF1ZXhmb29iYXJiYXo="
+```
+
+```ts
+import { PasswordHasher } from "@/blocks/password-hash/core";
+
+// One instance per process. Construction validates everything and throws
+// InvalidPepperError / InvalidConfigError immediately on bad configuration.
+export const passwordHasher = new PasswordHasher();
+```
+
+### Registration and login with transparent upgrades
+
+```ts
+import express from "express";
+import { passwordHasher } from "./security";
+import { db } from "./db";
+
+// Generate once at startup so parameters always match real hashes.
+const DUMMY_HASH = await passwordHasher.hashPassword("timing-equalizer");
+
+const app = express();
+
+app.post("/register", async (req, res) => {
+  const { email, password } = req.body;
+  const passwordHash = await passwordHasher.hashPassword(password);
+  await db.users.create({ email, passwordHash });
+  res.status(201).json({ ok: true });
+});
+
+app.post("/login", async (req, res) => {
+  const { email, password } = req.body;
+  const user = await db.users.findByEmail(email);
+
+  // Same Argon2 work happens whether or not the user exists.
+  // This prevents timing attacks that reveal which emails are registered.
+  const valid = user
+    ? await passwordHasher.verifyPassword(password, user.passwordHash)
+    : await passwordHasher.verifyPassword(password, DUMMY_HASH); // always false
+
+  if (!valid) {
+    return res.status(401).json({ error: "Invalid credentials" });
+  }
+
+  // Upgrade hashes created under older/weaker/different parameters.
+  if (passwordHasher.needsRehash(user.passwordHash)) {
+    const upgraded = await passwordHasher.hashPassword(password);
+    await db.users.updatePasswordHash(user.id, upgraded);
+  }
+
+  res.json({ ok: true });
+});
+```
+
+### Timing equalization for unknown users
+
+If you skip Argon2 entirely when the email is unknown, response times leak which addresses are registered. Always verify against a dummy hash instead:
+
+```ts
+// Generate once at application startup from the same PasswordHasher instance.
+const DUMMY_HASH = await passwordHasher.hashPassword("timing-equalizer");
+
+// Unknown user path — burns the same CPU/memory as a real verification.
+const valid = await passwordHasher.verifyPassword(password, DUMMY_HASH); // always false
+```
+
+### Testing
+
+```ts
+describe("credential flow", () => {
+  const hasher = new PasswordHasher({
+    pepper: Buffer.alloc(32, 7).toString("base64"),
+    memoryCost: 8192, // fast parameters for tests only — never in production
+    timeCost: 1,
+    parallelism: 1,
+    outputLen: 32,
+    maxInputBytes: 128
+  });
+
+  it("round-trips a password", async () => {
+    const stored = await hasher.hashPassword("Sup3r-Secret!");
+    expect(await hasher.verifyPassword("Sup3r-Secret!", stored)).toBe(true);
+    expect(await hasher.verifyPassword("wrong", stored)).toBe(false);
+  });
+
+  it("rejects non-string input", async () => {
+    // @ts-expect-error
+    await expect(hasher.hashPassword(123)).rejects.toThrow(TypeError);
+  });
+
+  it("flags bcrypt-era hashes for migration", () => {
+    expect(hasher.needsRehash("$2b$10$abcdefghijklmnopqrstuv")).toBe(true);
+  });
+
+  it("flags hashes with weaker parameters", async () => {
+    const weakHasher = new PasswordHasher({
+      pepper: Buffer.alloc(32, 7).toString("base64"),
+      memoryCost: 4096,
+      timeCost: 1,
+      parallelism: 1,
+      outputLen: 32
+    });
+    const weakHash = await weakHasher.hashPassword("test");
+    expect(hasher.needsRehash(weakHash)).toBe(true);
+  });
+});
+```
+
+---
+
+## API Reference
+
+### PasswordHasher
+
+```ts
+class PasswordHasher {
+  constructor(overrides?: PasswordHashConfigOverrides);
+  async hashPassword(password: string): Promise<string>;
+  async verifyPassword(password: string, storedHash: string): Promise<boolean>;
+  needsRehash(storedHash: string): boolean;
+  get currentConfig(): Readonly<PasswordHashConfig>;
+}
+```
+
+Create one instance per process. The constructor validates configuration eagerly.
+
+### passwordHasher.hashPassword
+
+```ts
+async function hashPassword(password: string): Promise<string>;
+```
+
+Peppers and hashes the password, returning a PHC string to store.
+
+| Parameter  | Type     | Description                      |
+| ---------- | -------- | -------------------------------- |
+| `password` | `string` | Plaintext password (any Unicode) |
+
+**Returns** — `$argon2id$v=19$m=<memoryCost>,t=<timeCost>,p=<parallelism>$<salt>$<hash>`
+
+**Throws**
+
+- `PasswordTooLongError` — UTF-8 byte length exceeds `maxInputBytes`
+- `TypeError` — input is not a string
+
+### passwordHasher.verifyPassword
+
+```ts
+async function verifyPassword(password: string, storedHash: string): Promise<boolean>;
+```
+
+Verifies plaintext against a stored hash. Parameters are read from the hash itself, so hashes created under older configurations still verify.
+
+**Returns** — `true` only for an exact match against a well-formed Argon2id hash; `false` for wrong passwords, foreign algorithms (`bcrypt`, `argon2i`, `argon2d`), non-string stored hashes, and malformed input. Never throws for corrupt hashes.
+
+**Throws**
+
+- `PasswordTooLongError` — input exceeds `maxInputBytes`
+- `TypeError` — password is not a string
+
+### passwordHasher.needsRehash
+
+```ts
+function needsRehash(storedHash: string): boolean;
+```
+
+Returns `true` when the hash was produced under weaker or different parameters than the current configuration, uses a different Argon2 version, has a different output length, is not Argon2id at all, or cannot be parsed. Synchronous and side-effect free.
+
+### passwordHasher.currentConfig
+
+```ts
+get currentConfig(): Readonly<PasswordHashConfig>;
+```
+
+Snapshot of the resolved configuration. Mutating the returned object has no effect on the hasher.
+
+### loadConfig
+
+```ts
+function loadConfig(overrides?: PasswordHashConfigOverrides): PasswordHashConfig;
+```
+
+Resolves override → environment variable → default and validates everything. Exported for advanced setups that need the resolved values before constructing a hasher.
+
+### Error classes
+
+```ts
+class PasswordHashError extends Error {}
+class InvalidPepperError extends PasswordHashError {} // missing, non-base64, or < 32 decoded bytes
+class InvalidConfigError extends PasswordHashError {} // numeric parameter outside native limits
+class PasswordTooLongError extends PasswordHashError {} // message includes the configured byte limit
+```
+
+### Types
+
+```ts
+interface Argon2Params {
+  memoryCost: number; // KiB
+  timeCost: number;
+  parallelism: number;
+  outputLen: number; // bytes
+}
+
+interface PasswordHashConfig extends Argon2Params {
+  pepper: string; // base64, decodes to >= 32 bytes
+  maxInputBytes: number; // UTF-8 bytes
+}
+
+type PasswordHashConfigOverrides = Partial<PasswordHashConfig>;
+```
+
+---
+
+## Related Blocks
+
+- **Rate Limiter** — Throttle credential endpoints; Argon2 is expensive by design, so unthrottled login routes amplify into a memory DoS vector.
+- **Environment Configuration** — Validate `APP_PASSWORD_PEPPER` and the `ARGON2_*` variables alongside the rest of your environment schema.
+- **Logger** — Log verification failures and rehash events, but never passwords, hashes, or the pepper itself.
+
+---
+
+## FAQ
+
+**Why an HMAC pre-hash instead of passing the password straight to Argon2?**
+
+It lets the pepper act as a secret key rather than another string input. An attacker with only the database cannot evaluate guesses offline, because every candidate requires the HMAC key. As a bonus, the fixed 32-byte digest gives Argon2 uniform input regardless of password length. This mirrors the classic "peppered hashing" strategy from the OWASP cheat sheet while keeping standard, portable PHC output.
+
+**Why does the stored hash contain no trace of the pepper?**
+
+Only HMAC digests ever reach Argon2, and the pepper lives solely in the HMAC key slot. The PHC string carries algorithm, version, parameters, salt, and digest — inspect one; nothing in it decodes to your secret.
+
+**I changed `ARGON2_MEMORY_COST` (or any other parameter) in production. Did I break existing logins?**
+
+No. Verification reads the parameters from each stored hash, so old hashes keep working. `needsRehash()` reports `true` for any hash whose memory cost, time cost, parallelism, output length, or version differs from the current configuration, letting you upgrade lazily on login.
+
+**Why did verification throw for one user and return `false` for everyone else?**
+
+A thrown `PasswordTooLongError` or `TypeError` means the submitted password was oversized or not a string — a caller mistake worth surfacing loudly. Corrupted or foreign hashes never throw; they return `false` so a hostile database value cannot crash your login route.
+
+**Can I migrate users from bcrypt?**
+
+Not automatically, by design — the verifier rejects `$2b$` hashes to prevent downgrade confusion. Detect the prefix yourself, authenticate the user through your legacy path once, then store `hashPassword()` output. From then on this block handles them, and `needsRehash()` stays `false`.
+
+**My test suite passes a low `memoryCost`. Is that safe?**
+
+For tests, yes — that is what overrides exist for. Just make sure production reads its parameters from the environment and that no test fixture leaks into deployment configuration. The block enforces validity, not intent.
+
+**Does the block enforce a minimum password length?**
+
+No. It hashes empty strings happily because length policy varies by product and jurisdiction. Enforce your minimum (and breach-list checks) at registration.

--- a/apps/web/lib/landing-constants.ts
+++ b/apps/web/lib/landing-constants.ts
@@ -255,6 +255,13 @@ export const BLOCKS_CATALOG = {
       tag: "Config",
       description: "Type-safe environment variable parser and validator with Zod schemas.",
       command: "blockend-cli add env-config"
+    },
+    {
+      name: "System Health Check Monitoring",
+      tag: "DevOps",
+      description:
+        "Framework-agnostic health assessment suite for monitoring application and dependency health.",
+      command: "blockend-cli add health-check"
     }
   ] as CatalogBlock[]
 } as const;
@@ -267,8 +274,7 @@ export const FRAMEWORKS = {
   items: [
     { name: "Express", icon: "node-js", color: "text-pulse-green" },
     { name: "Fastify", icon: "bolt", color: "text-acid-lime" },
-    { name: "Hono", icon: "fire", color: "text-coral-red" },
-    { name: "Next.js API", icon: "n", color: "text-paper" }
+    { name: "Hono/node-server", icon: "fire", color: "text-coral-red" }
   ] as Framework[]
 } as const;
 
@@ -347,7 +353,7 @@ export const FAQ_SECTION = {
     {
       question: "Which HTTP backend frameworks are supported?",
       answer:
-        "Blockend natively supports Express, Fastify, Hono, and Next.js API route handlers with tailored type definitions for each."
+        "Blockend natively supports Express, Fastify, and Hono with tailored type definitions for each."
     },
     {
       question: "Can I use Blockend in existing production codebases?",

--- a/blocks/password-hash/config.test.ts
+++ b/blocks/password-hash/config.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { loadConfig } from "./config";
+import { InvalidPepperError } from "./errors";
+
+describe("Configuration Loading and Validation", () => {
+  const VALID_PEPPER = Buffer.alloc(32, 1).toString("base64"); // decodes to 32 bytes
+
+  beforeEach(() => {
+    vi.stubEnv("APP_PASSWORD_PEPPER", VALID_PEPPER);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("pepper requirement (plan 1.1)", () => {
+    it("throws InvalidPepperError when APP_PASSWORD_PEPPER is missing entirely", () => {
+      vi.stubEnv("APP_PASSWORD_PEPPER", undefined);
+      expect(() => loadConfig()).toThrow(InvalidPepperError);
+    });
+
+    it("throws InvalidPepperError when APP_PASSWORD_PEPPER is empty", () => {
+      vi.stubEnv("APP_PASSWORD_PEPPER", "");
+      expect(() => loadConfig()).toThrow(InvalidPepperError);
+      expect(() => loadConfig()).toThrow(/APP_PASSWORD_PEPPER/);
+    });
+  });
+
+  describe("pepper length (plan 1.2)", () => {
+    it("throws InvalidPepperError when pepper decodes to less than 32 bytes", () => {
+      vi.stubEnv("APP_PASSWORD_PEPPER", Buffer.alloc(31, 2).toString("base64"));
+      expect(() => loadConfig()).toThrow(InvalidPepperError);
+    });
+
+    it("accepts a pepper that decodes to exactly 32 bytes", () => {
+      const config = loadConfig();
+      expect(config.pepper).toBe(VALID_PEPPER);
+    });
+
+    it("accepts a pepper longer than 32 bytes", () => {
+      vi.stubEnv("APP_PASSWORD_PEPPER", Buffer.alloc(64, 3).toString("base64"));
+      expect(() => loadConfig()).not.toThrow();
+    });
+  });
+
+  describe("pepper format (plan 1.3)", () => {
+    it("rejects a long string containing non-base64 characters", () => {
+      // Long enough that the lenient decoder would produce >= 32 bytes,
+      // so only strict format validation can reject it.
+      vi.stubEnv(
+        "APP_PASSWORD_PEPPER",
+        "not*valid*base64*but*decodes*long*enough*to*fool*a*lenient*reader"
+      );
+      expect(() => loadConfig()).toThrow(InvalidPepperError);
+    });
+
+    it("rejects a pepper with invalid characters even when length would suffice", () => {
+      vi.stubEnv("APP_PASSWORD_PEPPER", `${"A".repeat(48)}!`);
+      expect(() => loadConfig()).toThrow(InvalidPepperError);
+    });
+
+    it("rejects a whitespace-only pepper", () => {
+      vi.stubEnv("APP_PASSWORD_PEPPER", "   ");
+      expect(() => loadConfig()).toThrow(InvalidPepperError);
+    });
+
+    it("rejects base64 with incorrect padding placement", () => {
+      // 'QQ==' in the middle of the string is not canonical base64
+      vi.stubEnv("APP_PASSWORD_PEPPER", `QQ==${Buffer.alloc(30, 4).toString("base64")}`);
+      expect(() => loadConfig()).toThrow(InvalidPepperError);
+    });
+
+    it("does not leak the pepper value in the rejection message", () => {
+      const bad = "not*valid*base64*but*decodes*long*enough*to*fool*a*lenient*reader";
+      vi.stubEnv("APP_PASSWORD_PEPPER", bad);
+      try {
+        loadConfig();
+        expect.unreachable("loadConfig should have thrown");
+      } catch (error) {
+        expect((error as Error).message).not.toContain(bad);
+      }
+    });
+  });
+
+  describe("default values (plan 1.4)", () => {
+    it("uses secure defaults when only pepper is set", () => {
+      const config = loadConfig();
+      expect(config).toEqual({
+        pepper: VALID_PEPPER,
+        memoryCost: 65536,
+        timeCost: 3,
+        parallelism: 1,
+        outputLen: 32,
+        maxInputBytes: 128
+      });
+    });
+  });
+
+  describe("environment variable overrides (plan 1.5)", () => {
+    it("overrides each default via its environment variable", () => {
+      vi.stubEnv("ARGON2_MEMORY_COST", "47104");
+      vi.stubEnv("ARGON2_TIME_COST", "4");
+      vi.stubEnv("ARGON2_PARALLELISM", "2");
+      vi.stubEnv("ARGON2_OUTPUT_LEN", "64");
+      vi.stubEnv("PASSWORD_MAX_INPUT_BYTES", "256");
+
+      const config = loadConfig();
+      expect(config.memoryCost).toBe(47104);
+      expect(config.timeCost).toBe(4);
+      expect(config.parallelism).toBe(2);
+      expect(config.outputLen).toBe(64);
+      expect(config.maxInputBytes).toBe(256);
+    });
+
+    it("lets constructor overrides win over environment variables (plan 1.6)", () => {
+      vi.stubEnv("ARGON2_MEMORY_COST", "47104");
+      vi.stubEnv("ARGON2_TIME_COST", "4");
+
+      const config = loadConfig({ memoryCost: 8192, timeCost: 1 });
+      expect(config.memoryCost).toBe(8192);
+      expect(config.timeCost).toBe(1);
+      // untouched values still come from env/defaults
+      expect(config.parallelism).toBe(1);
+      expect(config.outputLen).toBe(32);
+    });
+
+    it("supports partial overrides merged with defaults (plan 1.6)", () => {
+      const config = loadConfig({ maxInputBytes: 64 });
+      expect(config.maxInputBytes).toBe(64);
+      expect(config.memoryCost).toBe(65536);
+      expect(config.timeCost).toBe(3);
+    });
+  });
+
+  describe("numeric parameter validation (plan 1.7)", () => {
+    it.each([
+      ["ARGON2_MEMORY_COST", "-1"],
+      ["ARGON2_MEMORY_COST", "abc"],
+      ["ARGON2_MEMORY_COST", "3.5"],
+      ["ARGON2_TIME_COST", "0"],
+      ["ARGON2_TIME_COST", "-3"],
+      ["ARGON2_TIME_COST", "NaN"],
+      ["ARGON2_PARALLELISM", "0"],
+      ["ARGON2_PARALLELISM", "256"],
+      ["ARGON2_OUTPUT_LEN", "0"],
+      ["PASSWORD_MAX_INPUT_BYTES", "0"],
+      ["PASSWORD_MAX_INPUT_BYTES", "-128"]
+    ])("rejects %s=%s instead of passing it to Argon2", (name, value) => {
+      vi.stubEnv(name, value);
+      expect(() => loadConfig()).toThrow(/invalid|must be|positive/i);
+    });
+
+    it("treats empty numeric env vars as unset and falls back to defaults", () => {
+      vi.stubEnv("ARGON2_MEMORY_COST", "");
+      expect(loadConfig().memoryCost).toBe(65536);
+    });
+
+    it("rejects an override object containing impossible parameters", () => {
+      expect(() => loadConfig({ memoryCost: -8192 })).toThrow(/invalid|must be|positive/i);
+      expect(() => loadConfig({ timeCost: 0 })).toThrow(/invalid|must be|positive/i);
+      expect(() => loadConfig({ parallelism: 300 })).toThrow(/invalid|must be|positive/i);
+    });
+  });
+});

--- a/blocks/password-hash/config.ts
+++ b/blocks/password-hash/config.ts
@@ -1,0 +1,90 @@
+import type { PasswordHashConfig, PasswordHashConfigOverrides } from "./types";
+import { InvalidPepperError, InvalidConfigError } from "./errors";
+
+/**
+ * Load configuration from environment variables, with optional overrides.
+ * Environment variables:
+ *   APP_PASSWORD_PEPPER       (required)
+ *   ARGON2_MEMORY_COST        (default: 65536)
+ *   ARGON2_TIME_COST          (default: 3)
+ *   ARGON2_PARALLELISM        (default: 1)
+ *   ARGON2_OUTPUT_LEN         (default: 32)
+ *   PASSWORD_MAX_INPUT_BYTES  (default: 128)
+ */
+
+// RFC 4648 base64 (standard alphabet, optional padding). Node's decoder is
+// lenient and silently skips invalid characters, so the format must be
+// validated before decoding.
+const BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/;
+
+const MAX_UINT32 = 4294967295;
+const MAX_PARALLELISM = 255; // native binding limit
+
+function resolveNumber(
+  override: number | undefined,
+  envValue: string | undefined,
+  fallback: number,
+  label: string,
+  max: number = MAX_UINT32
+): number {
+  // Empty string is treated as unset so defaults still apply.
+  const resolved =
+    override ?? (envValue === undefined || envValue.trim() === "" ? fallback : Number(envValue));
+  if (!Number.isInteger(resolved) || resolved < 1 || resolved > max) {
+    const received = override !== undefined ? String(override) : (envValue ?? String(fallback));
+    throw new InvalidConfigError(
+      `${label} must be a positive integer between 1 and ${max}, but received "${received}"`
+    );
+  }
+  return resolved;
+}
+
+export function loadConfig(overrides: PasswordHashConfigOverrides = {}): PasswordHashConfig {
+  const pepper = overrides.pepper ?? process.env.APP_PASSWORD_PEPPER;
+  if (!pepper) {
+    throw new InvalidPepperError("APP_PASSWORD_PEPPER environment variable is required");
+  }
+  if (!BASE64_PATTERN.test(pepper)) {
+    throw new InvalidPepperError();
+  }
+
+  const pepperBuffer = Buffer.from(pepper, "base64");
+  if (pepperBuffer.length < 32) {
+    throw new InvalidPepperError();
+  }
+
+  return {
+    pepper,
+    memoryCost: resolveNumber(
+      overrides.memoryCost,
+      process.env.ARGON2_MEMORY_COST,
+      65536,
+      "ARGON2_MEMORY_COST"
+    ),
+    timeCost: resolveNumber(
+      overrides.timeCost,
+      process.env.ARGON2_TIME_COST,
+      3,
+      "ARGON2_TIME_COST"
+    ),
+    parallelism: resolveNumber(
+      overrides.parallelism,
+      process.env.ARGON2_PARALLELISM,
+      1,
+      "ARGON2_PARALLELISM",
+      MAX_PARALLELISM
+    ),
+    outputLen: resolveNumber(
+      overrides.outputLen,
+      process.env.ARGON2_OUTPUT_LEN,
+      32,
+      "ARGON2_OUTPUT_LEN"
+    ),
+    maxInputBytes: resolveNumber(
+      overrides.maxInputBytes,
+      process.env.PASSWORD_MAX_INPUT_BYTES,
+      128,
+      "PASSWORD_MAX_INPUT_BYTES"
+    )
+  };
+}

--- a/blocks/password-hash/core.test.ts
+++ b/blocks/password-hash/core.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { performance } from "node:perf_hooks";
+import { PasswordHasher } from "./core";
+import { InvalidPepperError, PasswordTooLongError } from "./errors";
+
+const PEPPER_A = Buffer.alloc(32, 7).toString("base64");
+const PEPPER_B = Buffer.alloc(32, 11).toString("base64");
+
+const LOW_MEMORY_CONFIG = {
+  pepper: PEPPER_A,
+  memoryCost: 8192, // 8 MiB – fast for unit tests
+  timeCost: 1,
+  parallelism: 1,
+  outputLen: 32,
+  maxInputBytes: 128
+};
+
+// OWASP-recommended production parameters (plan section 8 + final notes)
+const PRODUCTION_CONFIG = {
+  pepper: PEPPER_A,
+  memoryCost: 65536, // 64 MiB
+  timeCost: 3,
+  parallelism: 1,
+  outputLen: 32,
+  maxInputBytes: 128
+};
+
+/** PHC string layout: "" / "argon2id" / "v=19" / "m=..,t=..,p=.." / salt / digest */
+function phcParts(hash: string): string[] {
+  return hash.split("$");
+}
+
+function decodeB64(part: string | undefined): Buffer {
+  return Buffer.from(part ?? "", "base64");
+}
+
+describe("PasswordHasher Core", () => {
+  let hasher: PasswordHasher;
+
+  beforeAll(() => {
+    hasher = new PasswordHasher(LOW_MEMORY_CONFIG);
+  });
+
+  describe("construction and framework agnosticism (plan 9.x)", () => {
+    it("instantiates without any web framework imports", () => {
+      const plain = new PasswordHasher(LOW_MEMORY_CONFIG);
+      expect(plain).toBeInstanceOf(PasswordHasher);
+      expect(typeof plain.hashPassword).toBe("function");
+      expect(typeof plain.verifyPassword).toBe("function");
+      expect(typeof plain.needsRehash).toBe("function");
+    });
+
+    it("exposes async methods that return real Promises", async () => {
+      const pending = hasher.hashPassword("async-check");
+      expect(pending).toBeInstanceOf(Promise);
+      await expect(pending).resolves.toMatch(/^\$argon2id\$/);
+      const verification = hasher.verifyPassword("x", "not-a-hash");
+      expect(verification).toBeInstanceOf(Promise);
+      await expect(verification).resolves.toBe(false);
+    });
+
+    it("currentConfig returns a defensive copy", () => {
+      const snapshot = hasher.currentConfig;
+      expect(snapshot.memoryCost).toBe(8192);
+      (snapshot as { memoryCost: number }).memoryCost = 1;
+      expect(hasher.currentConfig.memoryCost).toBe(8192);
+    });
+  });
+
+  describe("pepper application (plan 2.x)", () => {
+    it("produces verifiable output for both minimal and maximal input lengths", async () => {
+      // Indirect proof the HMAC pre-hash yields a uniform fixed-size buffer:
+      // 1-byte and maxInputBytes passwords take the identical hashing path.
+      const tiny = await hasher.hashPassword("a");
+      const max = await hasher.hashPassword("a".repeat(128));
+      await expect(hasher.verifyPassword("a", tiny)).resolves.toBe(true);
+      await expect(hasher.verifyPassword("a".repeat(128), max)).resolves.toBe(true);
+    });
+
+    it("uses the decoded pepper bytes as the HMAC key (same password, different peppers)", async () => {
+      const hashA = await hasher.hashPassword("cross-pepper");
+      const hashB = await new PasswordHasher({
+        ...LOW_MEMORY_CONFIG,
+        pepper: PEPPER_B
+      }).hashPassword("cross-pepper");
+      expect(hashA.split("$")[5]).not.toBe(hashB.split("$")[5]);
+      await expect(hasher.verifyPassword("cross-pepper", hashB)).resolves.toBe(false);
+      await expect(
+        new PasswordHasher({ ...LOW_MEMORY_CONFIG, pepper: PEPPER_B }).verifyPassword(
+          "cross-pepper",
+          hashA
+        )
+      ).resolves.toBe(false);
+    });
+
+    it("never exposes the pepper in the stored hash or thrown errors (plan 2.3)", async () => {
+      const rawPepperBytes = Buffer.from(PEPPER_A, "base64");
+      const stored = await hasher.hashPassword("leak-check");
+      expect(stored).not.toContain(PEPPER_A);
+      expect(stored).not.toContain(rawPepperBytes.toString("hex"));
+      expect(stored.toLowerCase()).not.toContain(rawPepperBytes.toString("latin1").toLowerCase());
+
+      try {
+        await hasher.hashPassword("x".repeat(1000));
+        expect.unreachable("should have thrown");
+      } catch (error) {
+        expect((error as Error).message).not.toContain(PEPPER_A);
+      }
+    });
+  });
+
+  describe("hashPassword (plan 3.x)", () => {
+    it("returns a valid Argon2id PHC string with embedded parameters (plan 3.1, 3.5)", async () => {
+      const stored = await hasher.hashPassword("CorrectHorseBatteryStaple");
+      expect(stored).toMatch(/^\$argon2id\$v=19\$m=8192,t=1,p=1\$[A-Za-z0-9+/]+\$[A-Za-z0-9+/]+$/);
+      expect(stored.slice(1, 9)).toBe("argon2id"); // algorithm identifier is Argon2id
+      expect(stored).not.toMatch(/^\$argon2[i d]\$/i);
+    });
+
+    it("generates a unique salt per hash (plan 3.2)", async () => {
+      const first = await hasher.hashPassword("SamePassword");
+      const second = await hasher.hashPassword("SamePassword");
+      expect(first).not.toBe(second);
+      expect(phcParts(first)[4]).not.toBe(phcParts(second)[4]);
+    });
+
+    it("uses a salt of at least 16 bytes (plan 3.3)", async () => {
+      const stored = await hasher.hashPassword("salt-length");
+      const salt = decodeB64(phcParts(stored)[4]);
+      expect(salt.length).toBeGreaterThanOrEqual(16);
+    });
+
+    it("emits an output equal to config.outputLen bytes (plan 3.4)", async () => {
+      const custom = new PasswordHasher({ ...LOW_MEMORY_CONFIG, outputLen: 64 });
+      const stored = await custom.hashPassword("output-len");
+      expect(decodeB64(phcParts(stored)[5]).length).toBe(64);
+
+      const defaultStored = await hasher.hashPassword("output-len-default");
+      expect(decodeB64(phcParts(defaultStored)[5]).length).toBe(32);
+    });
+
+    it("accepts a password exactly at maxInputBytes and rejects one byte more (plan 3.6)", async () => {
+      await expect(hasher.hashPassword("a".repeat(128))).resolves.toMatch(/^\$argon2id\$/);
+      await expect(hasher.hashPassword("a".repeat(129))).rejects.toThrow(PasswordTooLongError);
+    });
+
+    it("counts multi-byte characters in bytes, not characters (plan 3.6, 10.3)", async () => {
+      // '€' is 3 bytes in UTF-8: 42 chars = 126 bytes (ok), 43 chars = 129 bytes (too long)
+      await expect(hasher.hashPassword("€".repeat(42))).resolves.toMatch(/^\$argon2id\$/);
+      await expect(hasher.hashPassword("€".repeat(43))).rejects.toThrow(PasswordTooLongError);
+      // 100 × '€' = 300 bytes, far beyond the limit
+      await expect(hasher.hashPassword("€".repeat(100))).rejects.toThrow(PasswordTooLongError);
+    });
+
+    it("round-trips unicode passwords with emoji and accents (plan 10.3)", async () => {
+      const unicode = "pässwörd-🔐-日本語";
+      const stored = await hasher.hashPassword(unicode);
+      await expect(hasher.verifyPassword(unicode, stored)).resolves.toBe(true);
+      await expect(hasher.verifyPassword("pässwörd-🔐-日本", stored)).resolves.toBe(false);
+    });
+
+    it("hashes an empty password by design; minimum-length policy belongs to callers (plan 10.1)", async () => {
+      const stored = await hasher.hashPassword("");
+      expect(stored).toMatch(/^\$argon2id\$/);
+      await expect(hasher.verifyPassword("", stored)).resolves.toBe(true);
+    });
+
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+      ["number", 12345]
+    ])("rejects %s instead of producing a hash (plan 10.2)", async (_, bad) => {
+      const input = bad as unknown as string;
+      await expect(hasher.hashPassword(input)).rejects.toThrow(TypeError);
+    });
+  });
+
+  describe("verifyPassword (plan 4.x)", () => {
+    it("verifies the correct password (plan 4.1)", async () => {
+      const password = "MySecretPassword123!";
+      const stored = await hasher.hashPassword(password);
+      await expect(hasher.verifyPassword(password, stored)).resolves.toBe(true);
+    });
+
+    it("rejects an incorrect password (plan 4.2)", async () => {
+      const stored = await hasher.hashPassword("OriginalPassword");
+      await expect(hasher.verifyPassword("WrongPassword", stored)).resolves.toBe(false);
+    });
+
+    it("still verifies hashes created with older/weaker parameters (plan 4.6)", async () => {
+      const legacy = new PasswordHasher({ ...LOW_MEMORY_CONFIG, memoryCost: 4096, timeCost: 1 });
+      const legacyHash = await legacy.hashPassword("legacy-user-password");
+      await expect(hasher.verifyPassword("legacy-user-password", legacyHash)).resolves.toBe(true);
+      await expect(hasher.verifyPassword("wrong", legacyHash)).resolves.toBe(false);
+    });
+
+    it("returns false for non-Argon2id hashes to prevent downgrade (plan 4.4)", async () => {
+      const foreign = [
+        "$2b$10$abcdefghijklmnopqrstuv", // bcrypt
+        "$argon2i$v=19$m=8192,t=1,p=1$c2FsdA$aGFzaA", // argon2i
+        "$argon2d$v=19$m=8192,t=1,p=1$c2FsdA$aGFzaA" // argon2d
+      ];
+      for (const hash of foreign) {
+        await expect(hasher.verifyPassword("password", hash)).resolves.toBe(false);
+      }
+    });
+
+    it("returns false (never throws) for malformed hashes (plan 4.5, 6.2)", async () => {
+      const malformed = [
+        "",
+        "garbage",
+        "$argon2id$",
+        "$argon2id$v=19$",
+        "$argon2id$v=19$m=8192,t=1,p=1$",
+        "$argon2id$v=19$m=8192,t=1,p=1$c2FsdA", // missing digest
+        "$argon2id$v=19$m=abc,t=x,p=y$!!!!$!!!!", // unparsable params
+        "$argon2id$v=19$m=8192,t=1,p=1$salt-with-$-dollar$aGFzaA", // tampered salt
+        "$argon2id$v=99$m=99999999999,t=99,p=255$!!!!$!!!!" // absurd params
+      ];
+      for (const hash of malformed) {
+        await expect(hasher.verifyPassword("password", hash)).resolves.toBe(false);
+      }
+    });
+
+    it("propagates PasswordTooLongError during verification (plan 4.7)", async () => {
+      const stored = await hasher.hashPassword("short");
+      await expect(hasher.verifyPassword("a".repeat(129), stored)).rejects.toThrow(
+        PasswordTooLongError
+      );
+      await expect(hasher.verifyPassword("a".repeat(200), stored)).rejects.toThrow(/129|128/);
+    });
+
+    it("does not leak the pepper through verification errors", async () => {
+      const stored = await hasher.hashPassword("no-leak");
+      try {
+        await hasher.verifyPassword("x".repeat(5000), stored);
+        expect.unreachable("should have thrown");
+      } catch (error) {
+        expect((error as Error).message).not.toContain(PEPPER_A);
+      }
+    });
+  });
+
+  describe("needsRehash (plan 5.x)", () => {
+    it("returns false when hash parameters match current config (plan 5.1)", async () => {
+      const stored = await hasher.hashPassword("fresh");
+      expect(hasher.needsRehash(stored)).toBe(false);
+    });
+
+    it("returns true when stored memory cost is weaker (plan 5.2)", async () => {
+      const old = new PasswordHasher({ ...LOW_MEMORY_CONFIG, memoryCost: 4096 });
+      const stored = await old.hashPassword("password");
+      expect(hasher.needsRehash(stored)).toBe(true);
+    });
+
+    it("returns false when stored parameters are stronger than required (plan 5.2 inverse)", async () => {
+      const stronger = new PasswordHasher({ ...LOW_MEMORY_CONFIG, memoryCost: 16384 });
+      const stored = await stronger.hashPassword("password");
+      expect(hasher.needsRehash(stored)).toBe(false);
+    });
+
+    it("returns true when stored time cost is weaker (plan 5.3)", async () => {
+      const current = new PasswordHasher({ ...LOW_MEMORY_CONFIG, timeCost: 2 });
+      const stored = await hasher.hashPassword("password"); // timeCost=1
+      expect(current.needsRehash(stored)).toBe(true);
+    });
+
+    it("returns true when stored parallelism differs, even if higher (plan 5.4)", async () => {
+      const higher = new PasswordHasher({ ...LOW_MEMORY_CONFIG, parallelism: 2 });
+      const stored = await higher.hashPassword("password");
+      expect(hasher.needsRehash(stored)).toBe(true); // current parallelism = 1
+    });
+
+    it("returns true for non-Argon2id hashes such as bcrypt (plan 5.5)", () => {
+      expect(hasher.needsRehash("$2b$10$abcdefghijklmnopqrstuv")).toBe(true);
+      expect(hasher.needsRehash("$argon2i$v=19$m=8192,t=1,p=1$c2FsdA$aGFzaA")).toBe(true);
+    });
+
+    it("returns true for malformed or unreadable hashes (plan 5.6)", () => {
+      expect(hasher.needsRehash("garbage")).toBe(true);
+      expect(hasher.needsRehash("")).toBe(true);
+      expect(hasher.needsRehash("$argon2id$v=19$m=nonsense")).toBe(true);
+    });
+
+    it("treats a future Argon2 version as requiring rehash (plan 5.7 decision: v != 19 -> rehash)", () => {
+      const futureVersion =
+        "$argon2id$v=20$m=8192,t=1,p=1$c2FsdHNhbHRzYWx0c2FsdA$aGFzaGhhc2hoYXNoaGFzaGhhc2g";
+      expect(hasher.needsRehash(futureVersion)).toBe(true);
+    });
+  });
+
+  describe("dummy hash timing equalization (plan 7.x)", () => {
+    it("produces a dummy hash with exactly the same parameters as real hashes (plan 7.1)", async () => {
+      const dummy = await hasher.hashPassword("dummy-password-for-missing-users");
+      expect(dummy).toMatch(/^\$argon2id\$v=19\$m=8192,t=1,p=1\$/);
+      expect(hasher.needsRehash(dummy)).toBe(false);
+    });
+
+    it("never authenticates against the dummy hash (plan 7.2)", async () => {
+      const dummy = await hasher.hashPassword("dummy-password-for-missing-users");
+      await expect(hasher.verifyPassword("attacker-password", dummy)).resolves.toBe(false);
+      await expect(hasher.verifyPassword("dummy-password-for-missing-users", dummy)).resolves.toBe(
+        true
+      ); // only its own preimage matches
+    });
+
+    it("verification cost is comparable to hashing cost (plan 4.3, 7.3, loose bound)", async () => {
+      const password = "timing-probe";
+      const stored = await hasher.hashPassword(password);
+
+      const hashStart = performance.now();
+      await hasher.hashPassword(password);
+      const hashMs = performance.now() - hashStart;
+
+      const verifyStart = performance.now();
+      const verified = await hasher.verifyPassword(password, stored);
+      const verifyMs = performance.now() - verifyStart;
+
+      expect(verified).toBe(true);
+      // Both run the same Argon2 work; allow generous slack for scheduler noise.
+      expect(verifyMs).toBeLessThan(Math.max(hashMs * 3, 250));
+    }, 10_000);
+  });
+
+  describe("production parameter benchmarks (plan 8.x)", () => {
+    let production: PasswordHasher;
+
+    beforeAll(() => {
+      production = new PasswordHasher(PRODUCTION_CONFIG);
+    });
+
+    it("hashes with OWASP parameters (64 MiB, t=3) in under 2 seconds (plan 8.1)", async () => {
+      const start = performance.now();
+      const stored = await production.hashPassword("benchmark-password");
+      const elapsed = performance.now() - start;
+
+      expect(stored).toMatch(/^\$argon2id\$v=19\$m=65536,t=3,p=1\$/);
+      expect(elapsed).toBeLessThan(2000);
+    }, 10_000);
+
+    it("verifies with production parameters in under 2 seconds (plan 8.2)", async () => {
+      const stored = await production.hashPassword("benchmark-password");
+
+      const start = performance.now();
+      const result = await production.verifyPassword("benchmark-password", stored);
+      const elapsed = performance.now() - start;
+
+      expect(result).toBe(true);
+      expect(elapsed).toBeLessThan(2000);
+    }, 10_000);
+
+    it("rejects oversized input under production configuration too", async () => {
+      await expect(production.hashPassword("a".repeat(129))).rejects.toThrow(PasswordTooLongError);
+    });
+  });
+
+  describe("integration flows (plan 11.x)", () => {
+    it("supports register -> login with correct and incorrect credentials (plan 11.1)", async () => {
+      const email = "user@example.com";
+      const database = new Map<string, string>();
+
+      // registration
+      database.set(email, await hasher.hashPassword("Sup3r-Secret!"));
+
+      // login: wrong attempt
+      expect(await hasher.verifyPassword("wrong-guess", database.get(email)!)).toBe(false);
+      // login: correct attempt
+      expect(await hasher.verifyPassword("Sup3r-Secret!", database.get(email)!)).toBe(true);
+    });
+
+    it("migrates a user's hash after a parameter upgrade (plan 11.1)", async () => {
+      const weak = new PasswordHasher(LOW_MEMORY_CONFIG);
+      const strong = new PasswordHasher({ ...LOW_MEMORY_CONFIG, timeCost: 2, memoryCost: 16384 });
+      const password = "upgrade-me";
+      const database = new Map<string, string>([["user", await weak.hashPassword(password)]]);
+
+      // login on the old hash still works...
+      const stored = database.get("user")!;
+      expect(await strong.verifyPassword(password, stored)).toBe(true);
+      // ...but triggers a transparent upgrade
+      expect(strong.needsRehash(stored)).toBe(true);
+      const upgraded = await strong.hashPassword(password);
+      database.set("user", upgraded);
+
+      expect(await strong.verifyPassword(password, upgraded)).toBe(true);
+      expect(strong.needsRehash(upgraded)).toBe(false);
+    });
+
+    it("handles legacy bcrypt records via verify=false plus needsRehash=true (plan 11.2)", async () => {
+      const legacyBcrypt = "$2b$10$CwTycUXWue0Thq9StjUM0uJ8.PxHptXCxrsPynTFNlLONSNJOmDQW"; // shape only
+      expect(await hasher.verifyPassword("plaintext-attempt", legacyBcrypt)).toBe(false);
+      expect(hasher.needsRehash(legacyBcrypt)).toBe(true);
+
+      // The application layer would then rehash the freshly supplied plaintext:
+      const migrated = await hasher.hashPassword("plaintext-attempt");
+      expect(await hasher.verifyPassword("plaintext-attempt", migrated)).toBe(true);
+      expect(hasher.needsRehash(migrated)).toBe(false);
+    });
+
+    it("rejects construction entirely when no pepper can be resolved", () => {
+      const previous = process.env.APP_PASSWORD_PEPPER;
+      delete process.env.APP_PASSWORD_PEPPER;
+      const { pepper: _unused, ...overridesWithoutPepper } = LOW_MEMORY_CONFIG;
+      try {
+        expect(() => new PasswordHasher(overridesWithoutPepper)).toThrow(InvalidPepperError);
+        expect(() => new PasswordHasher()).toThrow(InvalidPepperError);
+      } finally {
+        if (previous !== undefined) process.env.APP_PASSWORD_PEPPER = previous;
+      }
+    });
+  });
+});

--- a/blocks/password-hash/core.ts
+++ b/blocks/password-hash/core.ts
@@ -1,0 +1,175 @@
+import crypto from "node:crypto";
+import { hash, verify } from "@node-rs/argon2";
+import type { PasswordHashConfig, PasswordHashConfigOverrides } from "./types";
+import { loadConfig } from "./config";
+import { PasswordTooLongError } from "./errors";
+
+/**
+ * Framework-agnostic password hashing service using Argon2id.
+ * Can be used in Express, Fastify, Hono, or any Node.js environment.
+ */
+export class PasswordHasher {
+  private readonly config: PasswordHashConfig;
+  private readonly pepperBuffer: Buffer;
+
+  constructor(overrides: PasswordHashConfigOverrides = {}) {
+    this.config = loadConfig(overrides);
+    this.pepperBuffer = Buffer.from(this.config.pepper, "base64");
+  }
+
+  /**
+   * Apply pepper using HMAC-SHA256.
+   * The result is always 32 bytes.
+   * Enforces maximum input byte length.
+   */
+  private applyPepper(password: string): Buffer {
+    if (typeof password !== "string") {
+      throw new TypeError("password must be a string");
+    }
+
+    const byteLength = Buffer.byteLength(password, "utf8");
+    if (byteLength > this.config.maxInputBytes) {
+      throw new PasswordTooLongError(this.config.maxInputBytes);
+    }
+
+    return crypto.createHmac("sha256", this.pepperBuffer).update(password, "utf8").digest();
+  }
+
+  /**
+   * Hash a plaintext password and return a PHC string.
+   * The peppered digest is passed as base64 because @node-rs/argon2's
+   * verify() rejects raw binary buffers ("invalid utf-8 sequence"), while
+   * a fixed-width ASCII encoding stays byte-stable across hash and verify.
+   */
+  async hashPassword(password: string): Promise<string> {
+    const peppered = this.applyPepper(password).toString("base64");
+    const salt = crypto.randomBytes(16); // 128-bit salt
+
+    return hash(peppered, {
+      algorithm: 2, // Argon2id
+      memoryCost: this.config.memoryCost,
+      timeCost: this.config.timeCost,
+      parallelism: this.config.parallelism,
+      outputLen: this.config.outputLen,
+      salt
+    });
+  }
+
+  /**
+   * Verify a plaintext password against a stored Argon2id PHC string.
+   * Returns false if the hash is not Argon2id or verification fails.
+   * Throws PasswordTooLongError / TypeError for caller mistakes
+   * (same policy as hashing).
+   */
+  async verifyPassword(password: string, storedHash: string): Promise<boolean> {
+    if (typeof storedHash !== "string" || !storedHash.startsWith("$argon2id$")) {
+      return false;
+    }
+
+    // Deliberately outside try/catch: caller mistakes such as oversized
+    // passwords or non-string input must propagate instead of being
+    // masked as a failed login.
+    const peppered = this.applyPepper(password).toString("base64");
+
+    try {
+      return await verify(storedHash, peppered);
+    } catch {
+      // Malformed hash, unsupported parameters, or native binding error.
+      // Treat as verification failure — never throw for corrupt stored data.
+      return false;
+    }
+  }
+
+  /**
+   * Check if a stored hash was created with weaker or different parameters
+   * and should be rehashed.
+   */
+  needsRehash(storedHash: string): boolean {
+    if (typeof storedHash !== "string" || !storedHash.startsWith("$argon2id$")) {
+      return true;
+    }
+
+    const params = this.extractPhcParams(storedHash);
+    if (!params) return true;
+
+    // Force rehash on version mismatch or any parameter that is weaker
+    // or different from the current configuration.
+    return (
+      params.version !== 19 ||
+      params.memoryCost < this.config.memoryCost ||
+      params.timeCost < this.config.timeCost ||
+      params.parallelism !== this.config.parallelism ||
+      params.outputLen !== this.config.outputLen
+    );
+  }
+
+  /**
+   * Expose current configuration (read-only).
+   */
+  get currentConfig(): Readonly<PasswordHashConfig> {
+    return { ...this.config };
+  }
+
+  /**
+   * Parse the parameter section of a PHC string.
+   * Returns null on any parse failure.
+   *
+   * Expected form: $argon2id$v=19$m=65536,t=3,p=1$salt$hash
+   * (outputLen is not always present in the PHC string produced by
+   * @node-rs/argon2; we treat a missing value as the library default of 32)
+   */
+  private extractPhcParams(storedHash: string): {
+    version: number;
+    memoryCost: number;
+    timeCost: number;
+    parallelism: number;
+    outputLen: number;
+  } | null {
+    // Split: ["", "argon2id", "v=19", "m=65536,t=3,p=1", "salt", "hash"]
+    const parts = storedHash.split("$");
+    if (parts.length < 5 || parts[1] !== "argon2id") {
+      return null;
+    }
+
+    const versionPart = parts[2];
+    const paramPart = parts[3];
+
+    // Explicit guards — TypeScript cannot always narrow array access
+    if (!versionPart || !paramPart || !versionPart.startsWith("v=")) {
+      return null;
+    }
+
+    const version = parseInt(versionPart.slice(2), 10);
+    if (Number.isNaN(version)) return null;
+
+    const paramMap = new Map<string, number>();
+    for (const pair of paramPart.split(",")) {
+      const [key, value] = pair.split("=");
+      if (!key || value === undefined) continue;
+      const num = parseInt(value, 10);
+      if (!Number.isNaN(num)) {
+        paramMap.set(key, num);
+      }
+    }
+
+    const memoryCost = paramMap.get("m");
+    const timeCost = paramMap.get("t");
+    const parallelism = paramMap.get("p");
+
+    if (memoryCost === undefined || timeCost === undefined || parallelism === undefined) {
+      return null;
+    }
+
+    // @node-rs/argon2 does not always emit "l=" (output length).
+    // Fall back to the common default of 32 when absent.
+    const outputLen = paramMap.get("l") ?? 32;
+
+    return {
+      version,
+      memoryCost,
+      timeCost,
+      parallelism,
+      outputLen
+    };
+  }
+}

--- a/blocks/password-hash/errors.test.ts
+++ b/blocks/password-hash/errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { PasswordHashError, InvalidPepperError, PasswordTooLongError } from "./errors";
+
+describe("Error Classes", () => {
+  it("PasswordHashError extends Error", () => {
+    const err = new PasswordHashError("generic");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("PasswordHashError");
+    expect(err.message).toBe("generic");
+  });
+
+  it("InvalidPepperError has correct name and default message", () => {
+    const err = new InvalidPepperError();
+    expect(err).toBeInstanceOf(PasswordHashError);
+    expect(err.name).toBe("InvalidPepperError");
+    expect(err.message).toContain("at least 32 bytes");
+  });
+
+  it("PasswordTooLongError includes max bytes in message", () => {
+    const err = new PasswordTooLongError(128);
+    expect(err).toBeInstanceOf(PasswordHashError);
+    expect(err.name).toBe("PasswordTooLongError");
+    expect(err.message).toContain("128");
+  });
+
+  it("error hierarchy is intact for instanceof checks", () => {
+    expect(new InvalidPepperError()).toBeInstanceOf(Error);
+    expect(new PasswordTooLongError(64)).toBeInstanceOf(Error);
+    expect(new PasswordHashError("x")).not.toBeInstanceOf(InvalidPepperError);
+  });
+
+  it("messages never embed caller-supplied secrets", () => {
+    const secretish = "super-secret-pepper-material";
+    const err = new PasswordTooLongError(128);
+    expect(err.message).not.toContain(secretish);
+  });
+});

--- a/blocks/password-hash/errors.ts
+++ b/blocks/password-hash/errors.ts
@@ -1,0 +1,27 @@
+export class PasswordHashError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PasswordHashError";
+  }
+}
+
+export class InvalidPepperError extends PasswordHashError {
+  constructor(message = "Pepper must be a base64-encoded string of at least 32 bytes") {
+    super(message);
+    this.name = "InvalidPepperError";
+  }
+}
+
+export class InvalidConfigError extends PasswordHashError {
+  constructor(message = "Invalid password-hash configuration parameters") {
+    super(message);
+    this.name = "InvalidConfigError";
+  }
+}
+
+export class PasswordTooLongError extends PasswordHashError {
+  constructor(maxBytes: number) {
+    super(`Password exceeds maximum allowed byte length (${maxBytes} bytes)`);
+    this.name = "PasswordTooLongError";
+  }
+}

--- a/blocks/password-hash/types.ts
+++ b/blocks/password-hash/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Core configuration for Argon2id hashing.
+ */
+export interface Argon2Params {
+  /** Memory cost in KiB (e.g., 65536 for 64 MiB) */
+  memoryCost: number;
+  /** Number of iterations */
+  timeCost: number;
+  /** Degree of parallelism (use 1 for web apps) */
+  parallelism: number;
+  /** Length of the hash output in bytes */
+  outputLen: number;
+}
+
+/**
+ * Full configuration including pepper and input limits.
+ */
+export interface PasswordHashConfig extends Argon2Params {
+  /** Base64-encoded pepper (must decode to ≥32 bytes) */
+  pepper: string;
+  /** Maximum allowed password byte length (prevent DoS) */
+  maxInputBytes: number;
+}
+
+/**
+ * Options that can be overridden when instantiating PasswordHasher.
+ */
+export type PasswordHashConfigOverrides = Partial<PasswordHashConfig>;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.2",
     "@hono/node-server": "^2.1.1",
+    "@node-rs/argon2": "^2.1.0",
     "@types/express": "^5.0.6",
     "@types/node": "^26.2.0",
     "@types/supertest": "^7.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@hono/node-server':
         specifier: ^2.1.1
         version: 2.1.1(hono@4.13.2)
+      '@node-rs/argon2':
+        specifier: ^2.1.0
+        version: 2.1.0
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -1212,6 +1215,92 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@node-rs/argon2-android-arm-eabi@2.1.0':
+    resolution: {integrity: sha512-hdWo5kb4eFRbHjdu4O6dVlRPI/CR1vbkJpe3Z9kF2s0Kp42428wg8AxI+8Cv4mygdW309BpUBf3sZaqXBNpdpw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/argon2-android-arm64@2.1.0':
+    resolution: {integrity: sha512-MHby1n9UzlVma3GiEYWNNqRhn2Z/90QwF2PFckGwucdz0HfdVX+lSKEcyfwcbvS5sJ9GAzhop3hXlUPxUYe72Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/argon2-darwin-arm64@2.1.0':
+    resolution: {integrity: sha512-5nayvL9wepOvTO5JmdaiDZ6bgHEsI/vksnXphM3UTy/cflARr9MoD1pBrMPs921hx2otURJhG0avg9hN0Q0KPw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/argon2-darwin-x64@2.1.0':
+    resolution: {integrity: sha512-7bFf3qH/PLQ5kU5GkxMF+dMz/tiT+0yFXILpOx4fgSFjw3wdXpGZt3wH4i6dHMURDcwYlNap0hJaX4h2E3JGng==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/argon2-freebsd-x64@2.1.0':
+    resolution: {integrity: sha512-01mVdl+7bjSW0to5xcEzueq7BuYbz3476/dmLMXziJf8fhykzr723YRNcGjOcHSU5fxNrElY9uVeUoow16vBrQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.1.0':
+    resolution: {integrity: sha512-NxZILF+Hqav6yzJTUFuZXTUC1VagTO4Vfd2HSlzkwankUa1B7goo0NLY2tUPw6MdqtLojkqVG5MZ26AaF49tHw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/argon2-linux-arm64-gnu@2.1.0':
+    resolution: {integrity: sha512-jpx2VwJLyAF/cM64HRigFBk67GwtQBcssYyVhvHqfmCEZz/CP//SV9bxE+uJOGIPKJo7wDg/5f2k3JY0PNMROg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@node-rs/argon2-linux-arm64-musl@2.1.0':
+    resolution: {integrity: sha512-xXAaPUlnPx/44qwaSekTG/g6/h5QCyrTayPLmvewJNyYz17vyBRmFKWLgv9Q3+NJwSvV88nVnCu/xkQbEPQaog==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@node-rs/argon2-linux-x64-gnu@2.1.0':
+    resolution: {integrity: sha512-ICnfyFaxZzr8OdAEwTPsAjx6gpNla1sI3miZJWAVCtZlw98Wo3Wd4H7tvW6S2NRJ1BIOf4l8Z7aX7h3fimXn5w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@node-rs/argon2-linux-x64-musl@2.1.0':
+    resolution: {integrity: sha512-f56jehb/IPTGBWWrvMjDGZWlQm/hKkH2VK/MxJ9u3kUR9PCacdtLFZmX4sL+qKeo4wsyhlD1EvlZF6nV1FSi3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@node-rs/argon2-win32-arm64-msvc@2.1.0':
+    resolution: {integrity: sha512-KH8lBdjoZLUiVG1GjJQIQPKhmddJmEbJbL+e3S7BKVq1wKl1mx+ClmhGtMtYp8ZtEIw8/BYIFUIjL3sBuWGEuQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/argon2-win32-ia32-msvc@2.1.0':
+    resolution: {integrity: sha512-zZ7NDHoKTgrjoUehNN7xvP+dA/M9krOp42l0MKns6TnMkwrp5nes9agEZsUy+0t0JoR8OQ8D7EUCNLh5BEn++w==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/argon2-win32-x64-msvc@2.1.0':
+    resolution: {integrity: sha512-JN/yNiX7u8Cw9XXTbRrjnlgzFjCiEQe6x97wJnMIsJ3vty89q0SAg504Otd9qy2ofQS2F5CCWvrOXhm/oyHaAQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/argon2@2.1.0':
+    resolution: {integrity: sha512-VBOWfM2u58/to3DFqTGJ2U5cJKQwmjN2zxzsQNZ5a2o8Z6aUrhvqQh8NdgotIF1Y0tMsBNtzOBDBdfvvkwJDSQ==}
+    engines: {node: '>= 10'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -6562,6 +6651,61 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@node-rs/argon2-android-arm-eabi@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-android-arm64@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-darwin-arm64@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-darwin-x64@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-freebsd-x64@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-gnu@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-musl@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-gnu@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-musl@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-win32-arm64-msvc@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-win32-ia32-msvc@2.1.0':
+    optional: true
+
+  '@node-rs/argon2-win32-x64-msvc@2.1.0':
+    optional: true
+
+  '@node-rs/argon2@2.1.0':
+    optionalDependencies:
+      '@node-rs/argon2-android-arm-eabi': 2.1.0
+      '@node-rs/argon2-android-arm64': 2.1.0
+      '@node-rs/argon2-darwin-arm64': 2.1.0
+      '@node-rs/argon2-darwin-x64': 2.1.0
+      '@node-rs/argon2-freebsd-x64': 2.1.0
+      '@node-rs/argon2-linux-arm-gnueabihf': 2.1.0
+      '@node-rs/argon2-linux-arm64-gnu': 2.1.0
+      '@node-rs/argon2-linux-arm64-musl': 2.1.0
+      '@node-rs/argon2-linux-x64-gnu': 2.1.0
+      '@node-rs/argon2-linux-x64-musl': 2.1.0
+      '@node-rs/argon2-win32-arm64-msvc': 2.1.0
+      '@node-rs/argon2-win32-ia32-msvc': 2.1.0
+      '@node-rs/argon2-win32-x64-msvc': 2.1.0
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8675,6 +8819,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   figures@6.1.0:
     dependencies:
@@ -10892,8 +11040,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@0.8.4: {}
 

--- a/registry/index.json
+++ b/registry/index.json
@@ -758,6 +758,31 @@
           }
         }
       }
+    },
+    "password-hash": {
+      "name": "Password Hashing",
+      "description": "Argon2id password hashing with HMAC-SHA256 peppering, automatic salting, and rehash detection.",
+      "version": "1.0.0",
+      "frameworks": ["*"],
+      "dependencies": ["@node-rs/argon2@^2.1.0"],
+      "devDependencies": ["vitest@^4.1.10", "@types/node@^26.2.0"],
+      "adapters": {
+        "*": {
+          "variants": {
+            "default": {
+              "files": [
+                { "source": "blocks/password-hash/types.ts", "target": "types.ts" },
+                { "source": "blocks/password-hash/errors.ts", "target": "errors.ts" },
+                { "source": "blocks/password-hash/errors.test.ts", "target": "errors.test.ts" },
+                { "source": "blocks/password-hash/config.ts", "target": "config.ts" },
+                { "source": "blocks/password-hash/config.test.ts", "target": "config.test.ts" },
+                { "source": "blocks/password-hash/core.ts", "target": "core.ts" },
+                { "source": "blocks/password-hash/core.test.ts", "target": "core.test.ts" }
+              ]
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds a new `password-hash` block for secure password hashing and verification using Argon2id with HMAC-SHA256 peppering.

### Changes

* Added `PasswordHasher` with Argon2id hashing and verification.
* Added HMAC-SHA256 pepper support.
* Added configuration options and validation.
* Added custom errors for invalid peppers and password length limits.
* Added comprehensive unit tests, including edge cases.
* Integrated `@node-rs/argon2`.
* Added the `password-hash` module to the registry with versioning and dependencies.
* Added documentation for the new password-hashing block.
* Updated the web landing page and Blocks Catalog section.
* Added a CTA to improve block discoverability.
* Updated the footer name.
* Added the health check block to the web block constants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a secure password-hashing block using Argon2id, peppering, salting, validation, verification, and rehash detection.
  - Added a System Health Check Monitoring catalog entry.
  - Updated supported framework listings, including Hono’s server adapter.
  - Added optional star-count display and refreshed the GitHub banner.

- **Documentation**
  - Added comprehensive password-hashing setup, usage, security, API, and troubleshooting documentation.

- **UI Improvements**
  - Added a full catalog link and improved responsive layouts across catalog and framework sections.
  - Updated footer attribution text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->